### PR TITLE
update

### DIFF
--- a/src/CompositeKey.php
+++ b/src/CompositeKey.php
@@ -128,7 +128,7 @@ trait CompositeKey
      */
     protected function setKeysForSaveQuery($query)
     {
-        if (!is_array($this->getKeyName())) {
+       if (!is_array($this->getKeyName())) {
             $query->where($this->getKeyName(), '=', $this->getKeyForSaveQuery());
             return $query;
         }
@@ -142,6 +142,7 @@ trait CompositeKey
         }
         return $query;
     }
+    
 
     public static function find($ids, $columns = ['*'])
     {

--- a/src/CompositeKey.php
+++ b/src/CompositeKey.php
@@ -200,5 +200,4 @@ trait CompositeKey
             return $result;
         }, array());
     }
-
 }


### PR DESCRIPTION
Declaration of App\Models\BaseModel::setKeysForSaveQuery(Illuminate\Database\Eloquent\Builder $query) should be compatible with Illuminate\Database\Eloquent\Model::setKeysForSaveQuery($query)